### PR TITLE
add test files for upgrader (AOD - single channel, but 2D variable)

### DIFF
--- a/testinput_tier_1/test_reference/upgrader_aod.nc4
+++ b/testinput_tier_1/test_reference/upgrader_aod.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dd169dc3abd1c4fcc371ab2707a6a27b7e915ad0778c8539dbb1ed78f0a4b42b
-size 60073
+oid sha256:bd00bfabceaa67dc4691e19fbed83917d6c2b94b7233858e90a75af7f8024de2
+size 60670

--- a/testinput_tier_1/test_reference/upgrader_aod.nc4
+++ b/testinput_tier_1/test_reference/upgrader_aod.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd169dc3abd1c4fcc371ab2707a6a27b7e915ad0778c8539dbb1ed78f0a4b42b
+size 60073

--- a/testinput_tier_1/upgrader_aod.nc4
+++ b/testinput_tier_1/upgrader_aod.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a91be0c26df9210da2f56422cd2f1ad09e3dfe4f37dd6058c933af0d1b65198
+size 18374

--- a/testinput_tier_1/upgrader_aod.nc4
+++ b/testinput_tier_1/upgrader_aod.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7a91be0c26df9210da2f56422cd2f1ad09e3dfe4f37dd6058c933af0d1b65198
-size 18374
+oid sha256:d11e0df61ce8e90594b02b75516129589eaee98db0f4dc584f4db784a9deb676
+size 19188


### PR DESCRIPTION
## Description

https://github.com/JCSDA-internal/ioda/pull/264 adds a new test, testing an upgrader for the case when there is only one "channel" variable, which should be output as 2D variable.

Added file (before upgrade):
```
netcdf upgrader_aod {
dimensions:
	nlocs = 10 ;
	nobs = 10 ;
	nrecs = 10 ;
	nvars = 1 ;
	nchans = 1 ;
variables:
	float frequency@VarMetaData(nchans) ;
	int polarization@VarMetaData(nchans) ;
	float wavenumber@VarMetaData(nchans) ;
	int gsi_use_flag@VarMetaData(nchans) ;
	int sensor_channel@VarMetaData(nchans) ;
	float latitude@MetaData(nlocs) ;
	float longitude@MetaData(nlocs) ;
	float time@MetaData(nlocs) ;
	int surface_type@MetaData(nlocs) ;
	int modis_deep_blue_flag@MetaData(nlocs) ;
	float aerosol_optical_depth_4@ObsValue(nlocs) ;
	float aerosol_optical_depth_4@GsiHofXBc(nlocs) ;
	float aerosol_optical_depth_4@GsiHofX(nlocs) ;
	float aerosol_optical_depth_4@GsiObsError(nlocs) ;
	int aerosol_optical_depth_4@MetaData(nlocs) ;
	int aerosol_optical_depth_4@PreQC(nlocs) ;
	float solar_zenith_angle@MetaData(nlocs) ;
	float solar_azimuth_angle@MetaData(nlocs) ;

// global attributes:
		:date_time = 2018041500 ;
		:satellite = "suomi_npp" ;
		:sensor = "v.viirs-m_npp" ;
		:observation_type = "Aod" ;
}
```

Test reference for the file after the upgrade:
```
netcdf upgrader_aod {
dimensions:
	nchans = 1 ;
	nlocs = 10 ;
	nobs = 10 ;
	nrecs = 10 ;
	nvars = 1 ;
variables:
	int nchans(nchans) ;
		nchans:suggested_chunk_dim = 1LL ;
	float nlocs(nlocs) ;
		nlocs:suggested_chunk_dim = 100LL ;
	float nobs(nobs) ;
		nobs:suggested_chunk_dim = 100LL ;
	float nrecs(nrecs) ;
		nrecs:suggested_chunk_dim = 100LL ;
	float nvars(nvars) ;
		nvars:suggested_chunk_dim = 100LL ;

// global attributes:
		string :_ioda_layout = "ObsGroup" ;
		:_ioda_layout_version = 0 ;
		:date_time = 2018041500 ;
		:satellite = "suomi_npp" ;
		:sensor = "v.viirs-m_npp" ;
		:observation_type = "Aod" ;

group: GsiHofX {
  variables:
  	float aerosol_optical_depth(nlocs, nchans) ;
  } // group GsiHofX

group: GsiHofXBc {
  variables:
  	float aerosol_optical_depth(nlocs, nchans) ;
  } // group GsiHofXBc

group: GsiObsError {
  variables:
  	float aerosol_optical_depth(nlocs, nchans) ;
  } // group GsiObsError

group: MetaData {
  variables:
  	int aerosol_optical_depth_4(nlocs) ;
  	float latitude(nlocs) ;
  	float longitude(nlocs) ;
  	int modis_deep_blue_flag(nlocs) ;
  	float solar_azimuth_angle(nlocs) ;
  	float solar_zenith_angle(nlocs) ;
  	int surface_type(nlocs) ;
  	float time(nlocs) ;
  } // group MetaData

group: ObsValue {
  variables:
  	float aerosol_optical_depth(nlocs, nchans) ;
  } // group ObsValue

group: PreQC {
  variables:
  	int aerosol_optical_depth(nlocs, nchans) ;
  } // group PreQC

group: VarMetaData {
  variables:
  	float frequency(nchans) ;
  	int gsi_use_flag(nchans) ;
  	int polarization(nchans) ;
  	int sensor_channel(nchans) ;
  	float wavenumber(nchans) ;
  } // group VarMetaData
}
```

## Dependencies

Adds test data for:
- [ ] https://github.com/JCSDA-internal/ioda/pull/264
Should be merged before the ioda PR.