### PR TITLE
Added files to be used by tests of the "read obs from separate file" option

### DIFF
--- a/testinput_tier_1/obsspace_grouping_distributed_0000.nc4
+++ b/testinput_tier_1/obsspace_grouping_distributed_0000.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8589083adfcda7be74ddcae0f2e6908bbba6d3afde272fcf9559f4fb831775e
+size 34057

--- a/testinput_tier_1/obsspace_grouping_distributed_0001.nc4
+++ b/testinput_tier_1/obsspace_grouping_distributed_0001.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31849fdb3ce7cc152682eacca3cd5b5e7aee462c3e3cf790e07b5aa1abeca1c2
+size 86105

--- a/testinput_tier_1/obsspace_grouping_distributed_0002.nc4
+++ b/testinput_tier_1/obsspace_grouping_distributed_0002.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d61a5e5d9382fe86bb81b2c64a55fc2125c9409153672c95efb30a50dd0095d
+size 34057


### PR DESCRIPTION
This PR adds test data needed by https://github.com/JCSDA-internal/ioda/pull/270.