### PR TITLE
Upgrader remove dimensions from the input file that are unused

### DIFF
--- a/testinput_tier_1/test_reference/upgrader_aod.nc4
+++ b/testinput_tier_1/test_reference/upgrader_aod.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd00bfabceaa67dc4691e19fbed83917d6c2b94b7233858e90a75af7f8024de2
-size 60670
+oid sha256:0af097dc45fdabbe7127235a068a15c1b6e826aa73faebc9d5b96fbc71c1aa5d
+size 59587

--- a/testinput_tier_1/test_reference/upgrader_gmi_gpm.nc4
+++ b/testinput_tier_1/test_reference/upgrader_gmi_gpm.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f348a265625c93c1bfb502c0fa47b7b3ef0591f25f05437c68fdc366020b974c
-size 76608
+oid sha256:94ccc4ddea06db96d4ec79edffcd85383adbaa7345e8c8cd58f2282d35f438a7
+size 72871


### PR DESCRIPTION
## Description

This PR adds the new reference files for the upgrader AOD and GMI_GMP tests. This is a companion to the PR in ioda that contains the upgrader code changes. The new reference files are identical to those they are replacing except with the unused dimensions removed.

### Issue(s) addressed

fixes jcsda-internal/ioda/issues/255

## Acceptance Criteria (Definition of Done)

The upgrader removes unused dimensions.

## Dependencies

- [ ] merge with JCSDA-internal/ioda/pull/296


## Impact

None

## Test Data

None