### PR TITLE
More netcdf compatibilty test files for the upgrader tests.

### DIFF
--- a/testinput_tier_1/test_reference/upgrader_gnssro.nc4
+++ b/testinput_tier_1/test_reference/upgrader_gnssro.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf06fde32503eb754e2ebde3359fbdf79447e16c7228d5be2e3f6eb3e539bad4
+size 51122

--- a/testinput_tier_1/upgrader_gnssro.nc4
+++ b/testinput_tier_1/upgrader_gnssro.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:872474f3a1f59363f04538212c092c730f5978d6f4cd1ddec2f13ef8ecb49ff6
+size 42590


### PR DESCRIPTION
## Description

This PR fixes the issue with the upgrader (#281) that was producing incompatible files with netcdf.

### Issue(s) addressed

- fixes #281

## Acceptance Criteria (Definition of Done)

The gnssro test file output of the upgrader can be read by ncdump (and other netcdf tools).

## Dependencies

- [ ] merge with JCSDA-internal/ioda/pull/297

## Impact

None

## Test Data

None