### PR TITLE
change GsiUseFlag mask in sondes file for ObsVector::packEigen test

### DIFF
--- a/testinput_tier_1/sondes_obs_2018041500_m.nc4
+++ b/testinput_tier_1/sondes_obs_2018041500_m.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:673792283f9e490b227c86b32691337bf0a3b5ea67fa7339d4fa0a80fb15a21f
-size 306431
+oid sha256:444e66d253409ad4faec6027250f7d7c5d5783cd9ba1b0b5952a76d95dc1ec70
+size 413293


### PR DESCRIPTION
## Description

This updates test data for https://github.com/JCSDA-internal/ioda/pull/319

Changes in data in `sondes_obs_2018041500_m.nc4`:
- `air_temperature@GsiUseFlag`, `eastward_wind@GsiUseFlag`, `northward_wind@GsiUseFlag`, `specific_humidity@GsiUseFlag` are changed to have `1` instead of all missing values (mask is set).
- At some random locations these masks are set to 0 (for `specific_humidity@GsiUseFlag` everywhere where the flag was set to -1).

## Impact

Has to be merged with
- [ ] ioda https://github.com/JCSDA-internal/ioda/pull/319
