### PR TITLE
Reference files for the new time_IodaIo.x tests.

### DIFF
--- a/testinput_tier_1/test_reference/amsua_n19_obs_2018041500_m_time_0000.nc4
+++ b/testinput_tier_1/test_reference/amsua_n19_obs_2018041500_m_time_0000.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:238c7ae9e26523d955449677801c309aa2d6adc0724bbf83cf5904d5c8b6af85
+size 130427

--- a/testinput_tier_1/test_reference/sondes_obs_2018041500_m_time_0000.nc4
+++ b/testinput_tier_1/test_reference/sondes_obs_2018041500_m_time_0000.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:491eee662ef5e7587971aa03fdceb48278f2c84b9099e55643384753ef73df5b
-size 305179
+oid sha256:ade91777c34cab5db5727fd67cff05a33eca0e5bef03a096f0012c0096233f71
+size 305374

--- a/testinput_tier_1/test_reference/sondes_obs_2018041500_m_time_0000.nc4
+++ b/testinput_tier_1/test_reference/sondes_obs_2018041500_m_time_0000.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:491eee662ef5e7587971aa03fdceb48278f2c84b9099e55643384753ef73df5b
+size 305179


### PR DESCRIPTION
## Description

This PR adds in test files for improved testing of the time_IodaIo.x application introduced in jcsda-internal/ioda/pull/330

### Issue(s) addressed

None, but it is very helpful for debugging https://github.com/JCSDA-internal/mpas-jedi/issues/575 and #327. https://github.com/JCSDA-internal/mpas-jedi/issues/575 is related to an issue with the ioda writer that was found when testing for the ioda 2.0.0 release and we decided to comment out some of the "obsdataout" specs to workaround it.

## Acceptance Criteria (Definition of Done)

The time_IodaIo.x application will create ioda output files when the "obsdataout" spec is used.

## Dependencies

- [ ] merge before or with jcsda-internal/ioda/pull/330

## Impact

None