### PR TITLE
Reference file update for the new time_IodaIo.x tests.

### DIFF
--- a/testinput_tier_1/test_reference/sondes_obs_2018041500_m_time_0000.nc4
+++ b/testinput_tier_1/test_reference/sondes_obs_2018041500_m_time_0000.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ade91777c34cab5db5727fd67cff05a33eca0e5bef03a096f0012c0096233f71
-size 305374
+oid sha256:061a301b63778f8ed882919db6067cc4c77cce4a4fe42db0a5ae10828fa26932
+size 308205


### PR DESCRIPTION
## Description

This PR update the sondes test reference for the time_IodaIo.x application introduced in jcsda-internal/ioda/pull/330

### Issue(s) addressed

None, but it is very helpful for debugging https://github.com/JCSDA-internal/mpas-jedi/issues/575 and #327. https://github.com/JCSDA-internal/mpas-jedi/issues/575 is related to an issue with the ioda writer that was found when testing for the ioda 2.0.0 release and we decided to comment out some of the "obsdataout" specs to workaround it.

## Acceptance Criteria (Definition of Done)

The time_IodaIo.x application will create ioda output files when the "obsdataout" spec is used.

## Dependencies

- [ ] merge before or with jcsda-internal/ioda/pull/330

## Impact

None