### PR TITLE
Updated SMAP obs file with properly built ioda-v2 file.

### DIFF
--- a/testinput_tier_1/smap_obs_2018041500_m.nc4
+++ b/testinput_tier_1/smap_obs_2018041500_m.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:802b6d296cace5d32cab5215cdf45b45e66f35e4baf736047261e2756882206f
-size 71392
+oid sha256:fda54c6c2c9124456261848e37d2d86f56f2ee9b72b899d38d56ff276602de9f
+size 70696


### PR DESCRIPTION
## Description

This PR updates the SMAP obs file with a properly built version. The current SMAP obs file has a fault with the dimension specs.

This issue was found in the ufo-data repository which also has a copy of the broken SMAP obs file.

### Issue(s) addressed

I'm going to issue a PR in ufo-data and have that PR close the "broken SMAP obs file" issue. This is a related fix since there is a copy of the broken SMAP obs file in this repo.

The ufo-data issue is jcsda-internal/ufo-data#34

## Acceptance Criteria (Definition of Done)

All ioda tests pass.

## Dependencies

None

## Impact

None
