### PR TITLE
Data for testing support for Boolean ObsSpace variables

### DIFF
--- a/testinput_tier_1/variable_assignment_testdata.nc
+++ b/testinput_tier_1/variable_assignment_testdata.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4d7bc6ad219ffa54944fa7ab66965b7d0883d87cf1386da6c904046c1e5437ac
-size 18254
+oid sha256:169ce7a931a02fdb9152008116b78fecb4c70dac13184c3413502b69077daccb
+size 18656

--- a/testinput_tier_1/variable_assignment_testdata.nc
+++ b/testinput_tier_1/variable_assignment_testdata.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:877c31a1489bca65d75b500d3c3382b331f8b2a5d46578fe20e39bf736ec2685
-size 56575
+oid sha256:4d7bc6ad219ffa54944fa7ab66965b7d0883d87cf1386da6c904046c1e5437ac
+size 18254


### PR DESCRIPTION
## Description

This PR modifies the `variable_assignment_testdata.nc` file in the following ways:
* out-of-date NetCDF attributes are removed to fix an "HDF5 error" appearing when the `develop` version of this file is opened with `ncdump`
* `MetaData/bool_variable_1` variable of type `byte` is added; it is needed by tests of the overload of `ObsSpace::get_db()` taking a `std::vector<bool>`
* the observation times are shifted so that most of them lie in the window used by the `test_ioda_obsspace` test (this makes it possible to use this NetCDF file from that test).

### Issue(s) addressed

Contributes to, but does not close, https://github.com/JCSDA-internal/ufo/issues/1473.

## Dependencies

None

## Impact

None