### PR TITLE
Warn about ODB files in which different obs sequences contain different varnos

### DIFF
--- a/testinput_tier_1/aircraft.odb
+++ b/testinput_tier_1/aircraft.odb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:116d25f9dbf7963b7f07dcfec98b777eaa84189a5132e837e1e5fd4785f339f1
-size 188763
+oid sha256:ebb92383862fe138b6345aaa8c67c0ce90684b7cb86d026f4e56b7d82d6ecce3
+size 79656

--- a/testinput_tier_1/truncatedaircraft.odb
+++ b/testinput_tier_1/truncatedaircraft.odb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a0f2fa4a237546a61d60790a3f147d859d682878573720b5fc0022c1d017088
+size 17243


### PR DESCRIPTION
## Description

This PR:
1. Adds an ODB file, `truncatedaircraft.odb`, obtained by truncating `aircraft.odb` to the first 37 rows; in this file one of the varnos occurs 8 times and others 7 times.
2. Removes rows with varno 29 (relative humidity) from `aircraft.odb`. These rows were present only in some obs sequences, so that before the change introduced in https://github.com/JCSDA-internal/ioda/pull/522 they were silently ignored (the `relative_humidity` variable was not created) and after that change they triggered an exception.

### Issue(s) addressed

Contributes to fixing https://github.com/JCSDA-internal/ioda/issues/521.

## Dependencies

None

## Impact

None