### PR TITLE
Bump version number to 2.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,5 +9,5 @@
 
 cmake_minimum_required( VERSION 3.3.2 FATAL_ERROR )
 
-project( ioda_data VERSION 2.2.0 DESCRIPTION "IODA Test Files" )
+project( ioda_data VERSION 2.3.0 DESCRIPTION "IODA Test Files" )
 


### PR DESCRIPTION
## Description

This PR bumps the version number in the project from 2.2.0 to 2.3.0.

### Issue(s) addressed

None

## Acceptance Criteria (Definition of Done)

All ctests pass. 

## Dependencies

- [ ] merge with jcsda-internal/ioda/pull/797

## Impact

None