### PR TITLE
release/skylab-v3: Remove duplicate obs (locations) in ioda output files

### DIFF
--- a/testinput_tier_1/dist_write_testdata.nc4
+++ b/testinput_tier_1/dist_write_testdata.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1a98ff4b5462e1738a4bb8aa0be316182bae4253756996b0bd2f88fabb8c47d
+size 8652

--- a/testinput_tier_1/test_reference/dist_write_atlas_out_0000.nc4
+++ b/testinput_tier_1/test_reference/dist_write_atlas_out_0000.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7a75cefec5c08d7180cc98eaba4831677d1a22061bb82fa0ca2e92a88b380d9
+size 22342

--- a/testinput_tier_1/test_reference/dist_write_halo_out_0000.nc4
+++ b/testinput_tier_1/test_reference/dist_write_halo_out_0000.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f7a75cefec5c08d7180cc98eaba4831677d1a22061bb82fa0ca2e92a88b380d9
+oid sha256:fc6ff34f1fa4cbf57bd119389c4b81cdf564f6c427274d5bdfbb1c370bb4c38e
 size 22342

--- a/testinput_tier_1/test_reference/dist_write_halo_out_0000.nc4
+++ b/testinput_tier_1/test_reference/dist_write_halo_out_0000.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7a75cefec5c08d7180cc98eaba4831677d1a22061bb82fa0ca2e92a88b380d9
+size 22342

--- a/testinput_tier_1/test_reference/dist_write_inefficient_out_0000.nc4
+++ b/testinput_tier_1/test_reference/dist_write_inefficient_out_0000.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7a75cefec5c08d7180cc98eaba4831677d1a22061bb82fa0ca2e92a88b380d9
+size 22342

--- a/testinput_tier_1/test_reference/dist_write_round_robin_out_0000.nc4
+++ b/testinput_tier_1/test_reference/dist_write_round_robin_out_0000.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8cea150cab4948ab24f228954171c4b5f70035a9285a6ecf7ca0482c84c15710
+size 22342


### PR DESCRIPTION
## Description

This PR provides new test files for the fix (jcsda-internal/ioda/pull/848) of the duplicate obs issue (jcsda-internal/ioda/issues/818).

### Issue(s) addressed

This PR with the companion (jcsda-internal/ioda/pull/848) resolves jcsda-internal/ioda/issues/818.

## Acceptance Criteria (Definition of Done)

ctests pass

## Dependencies

- [ ] merge with jcsda-internal/ioda/pull/848

## Impact

None