### PR TITLE
Merge release/skylab_v3 into develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,5 +9,5 @@
 
 cmake_minimum_required( VERSION 3.3.2 FATAL_ERROR )
 
-project( ioda_data VERSION 2.3.0 DESCRIPTION "IODA Test Files" )
+project( ioda_data VERSION 2.4.0 DESCRIPTION "IODA Test Files" )
 

--- a/testinput_tier_1/dist_write_testdata.nc4
+++ b/testinput_tier_1/dist_write_testdata.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1a98ff4b5462e1738a4bb8aa0be316182bae4253756996b0bd2f88fabb8c47d
+size 8652

--- a/testinput_tier_1/test_reference/dist_write_atlas_out_0000.nc4
+++ b/testinput_tier_1/test_reference/dist_write_atlas_out_0000.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7a75cefec5c08d7180cc98eaba4831677d1a22061bb82fa0ca2e92a88b380d9
+size 22342

--- a/testinput_tier_1/test_reference/dist_write_halo_out_0000.nc4
+++ b/testinput_tier_1/test_reference/dist_write_halo_out_0000.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc6ff34f1fa4cbf57bd119389c4b81cdf564f6c427274d5bdfbb1c370bb4c38e
+size 22342

--- a/testinput_tier_1/test_reference/dist_write_inefficient_out_0000.nc4
+++ b/testinput_tier_1/test_reference/dist_write_inefficient_out_0000.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7a75cefec5c08d7180cc98eaba4831677d1a22061bb82fa0ca2e92a88b380d9
+size 22342

--- a/testinput_tier_1/test_reference/dist_write_round_robin_out_0000.nc4
+++ b/testinput_tier_1/test_reference/dist_write_round_robin_out_0000.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8cea150cab4948ab24f228954171c4b5f70035a9285a6ecf7ca0482c84c15710
+size 22342


### PR DESCRIPTION
## Description

As the title says. Created separate branch because we want `release/skylab-v3` to stick around until the next release.

## Acceptance Criteria (Definition of Done)

PR merged

## Dependencies

none

## Impact

Release branches need to be merged for all repositories in order for develop to function correctly.