### PR TITLE
Properly assign a default fill value to an int64_t variable

### DIFF
--- a/testinput_tier_1/default_fill_values.nc4
+++ b/testinput_tier_1/default_fill_values.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e55f02fb9f1a19b4f37c204e1215d1b72aa652bb1d3fcfc7adc8c47caeedaca0
+size 15368

--- a/testinput_tier_1/test_reference/default_fill_values_out.nc4
+++ b/testinput_tier_1/test_reference/default_fill_values_out.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:defb80a4c5f0ec32efa24e7b29814f343612e8502c23b9a50d944565eb3d9d7e
+size 2244403


### PR DESCRIPTION
## Description

Test files for the new ctests associated with default fill value assignment.

### Issue(s) addressed

See jcsda-internal/ioda/pull/927

## Acceptance Criteria (Definition of Done)

All ctests pass.

## Dependencies

- [ ] merge with jcsda-internal/ioda/pull/927

## Impact

None