### PR TITLE
Test reference file updates for the new reader

### DIFF
--- a/testinput_tier_1/test_reference/amsua_n19_obs_2018041500_m_time_reader_pool.nc4
+++ b/testinput_tier_1/test_reference/amsua_n19_obs_2018041500_m_time_reader_pool.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:24313e741f599bca25215f29af9ab5333a2842ab11814b26769ef4af767d39a7
-size 138997
+oid sha256:b3beff41254ddff71523caea9ac338b2be5b2f577e97324c8142e51457209fc6
+size 143441

--- a/testinput_tier_1/test_reference/gnssro_obs_2021080606_s_time_reader_pool.nc4
+++ b/testinput_tier_1/test_reference/gnssro_obs_2021080606_s_time_reader_pool.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9929e4e2a27fda330ce13afa9ac4f7843b06bac7166f728718624ecee17f93f6
-size 72951
+oid sha256:69643794931d451f45f8e327d9be219e321c3ef17ed3d69e4fe892e7a9405dbe
+size 75352

--- a/testinput_tier_1/test_reference/sondes_obs_2018041500_m_time_reader_pool.nc4
+++ b/testinput_tier_1/test_reference/sondes_obs_2018041500_m_time_reader_pool.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ed92bce1246abf14b2847f3ea7ff944d780d07a9e47359370e1e501088ec4fee
-size 471485
+oid sha256:729d5a4d12df295aa6f05eda440556a5f539fb91b7e87babe1780df8c321cc9c
+size 481673


### PR DESCRIPTION
## Description

This PR include test reference file updates for the new reader. The only differences are the data type for the Location dimension variable changed from int to int64, and there is a new variable added named "destinationRank" (which denotes the destination rank for each location).

## Issue(s) addressed

This addresses ioda 974 along with the companion ioda PR

## Dependencies

List the other PRs that this PR is dependent on:
- [ ] merge with jcsda-internal/ioda/pull/1129

## Impact

Expected impact on downstream repositories:
None - these changes are for the new reader which is not selected by default. The old reader remains unchanged.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (N/A)
- [x] I have run the unit tests before creating the PR
