### PR TITLE
New test files for the python file merging capability

### DIFF
--- a/testinput_tier_1/sondes_file_merge_concat_in_0000.nc4
+++ b/testinput_tier_1/sondes_file_merge_concat_in_0000.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6eea28eabf90cc38cb92f186a515e5cdb7b7889e51864b67f4e9f40fccf14ed8
+size 3155933

--- a/testinput_tier_1/sondes_file_merge_concat_in_0001.nc4
+++ b/testinput_tier_1/sondes_file_merge_concat_in_0001.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4750fddeca5a51adfa702e2014b380247e78db6507fe12cf4374e628aebb48f9
+size 3155933

--- a/testinput_tier_1/test_reference/sondes_file_merge_concat_out.nc4
+++ b/testinput_tier_1/test_reference/sondes_file_merge_concat_out.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:361d775eba49602dcc70ed23dc8509b43de3de36e10d299b0e8ac915bf21185d
+size 385258


### PR DESCRIPTION
## Description

This PR adds in new test files for the python merge files script.

## Issue(s) addressed

Partially addresses jcsda-internal/ioda/issues/1170

## Dependencies

List the other PRs that this PR is dependent on:
- [x] merge with jcsda-internal/ioda/pull/1215
- [x] merge with jcsda-internal/solo/pull/52

## Impact

Expected impact on downstream repositories:
None, this is a brand new script.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (code comments)
- [x] I have run the unit tests before creating the PR
