### PR TITLE
Version number bump for skylab v8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,5 +9,5 @@
 
 cmake_minimum_required( VERSION 3.3.2 FATAL_ERROR )
 
-project( ioda_data VERSION 2.8.0 DESCRIPTION "IODA Test Files" )
+project( ioda_data VERSION 2.9.0 DESCRIPTION "IODA Test Files" )
 


### PR DESCRIPTION
## Description

Bump to version 2.9.0

## Issue(s) addressed

None

## Dependencies

List the other PRs that this PR is dependent on:
- [ ] merge before jcsda-internal/ioda/pull/1235

## Impact

Expected impact on downstream repositories:
None - no functional change

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (N/A)
- [x] I have run the unit tests before creating the PR
