### PR TITLE
Introduce standalone application that builds the input files sets for the new io pool based reader

### DIFF
--- a/testinput_tier_1/testwork/amsua_n19_obs_2018041500_m_0000.nc4
+++ b/testinput_tier_1/testwork/amsua_n19_obs_2018041500_m_0000.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:64407ec9c4c6833fc32b05cd3ee0c3357be3962bde694e0e1635fb2f1e3ee1c4
-size 146799

--- a/testinput_tier_1/testwork/amsua_n19_obs_2018041500_m_mpi7_0000.nc4
+++ b/testinput_tier_1/testwork/amsua_n19_obs_2018041500_m_mpi7_0000.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3fbcf38b9702b877181511b4351c57455d0c60de1f8b5b7ec56bf77d68ff014b
-size 112991

--- a/testinput_tier_1/testwork/amsua_n19_obs_2018041500_m_mpi7_0001.nc4
+++ b/testinput_tier_1/testwork/amsua_n19_obs_2018041500_m_mpi7_0001.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8f29f4bdd997628e04038ecfde26213ec10b959b4a71506c52ead455753a3d94
-size 112991

--- a/testinput_tier_1/testwork/amsua_n19_obs_2018041500_m_mpi7_0002.nc4
+++ b/testinput_tier_1/testwork/amsua_n19_obs_2018041500_m_mpi7_0002.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5ef3cff14cdd566bff90b1c0449617ecb91c7b969acd3f40c735cfc0402b5016
-size 112991

--- a/testinput_tier_1/testwork/amsua_n19_obs_2018041500_m_mpi7_0003.nc4
+++ b/testinput_tier_1/testwork/amsua_n19_obs_2018041500_m_mpi7_0003.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:187886a5493a27eaf0dc714d9b22ce0dd36177e0d11efdc268aa284f13e99b1f
-size 104799

--- a/testinput_tier_1/testwork/amsua_n19_obs_2018041500_m_mpi7_prep_file_info.nc4
+++ b/testinput_tier_1/testwork/amsua_n19_obs_2018041500_m_mpi7_prep_file_info.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d1f878af463352606f7705b8cdffff337b63d03fb90fc3752465fe1558df84e3
-size 17012

--- a/testinput_tier_1/testwork/amsua_n19_obs_2018041500_m_prep_file_info.nc4
+++ b/testinput_tier_1/testwork/amsua_n19_obs_2018041500_m_prep_file_info.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cf814027454e802284c86ef2578bbaab7e5febab9c2950d9ea3a8dbc80579487
-size 17012

--- a/testinput_tier_1/testwork/gnssro_obs_2021080606_s_0000.nc4
+++ b/testinput_tier_1/testwork/gnssro_obs_2021080606_s_0000.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fe0ebabf86e190c113a1d81a65c6523654d6963cec3ab3d7220d6b4e8a03de6a
-size 78450

--- a/testinput_tier_1/testwork/gnssro_obs_2021080606_s_mpi7_0000.nc4
+++ b/testinput_tier_1/testwork/gnssro_obs_2021080606_s_mpi7_0000.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:60b444be99c4bed197e21d563c19e70695beaf64351a57594040da752cf80021
-size 71906

--- a/testinput_tier_1/testwork/gnssro_obs_2021080606_s_mpi7_0001.nc4
+++ b/testinput_tier_1/testwork/gnssro_obs_2021080606_s_mpi7_0001.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0ce8e63da63508666fa28dc66fd84999a98c779e0d48eb5a6bcb3de53761545f
-size 71906

--- a/testinput_tier_1/testwork/gnssro_obs_2021080606_s_mpi7_0002.nc4
+++ b/testinput_tier_1/testwork/gnssro_obs_2021080606_s_mpi7_0002.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0e0cbb61df53fb2ebddbb53be81b8182ee97387f8824a96420fc1bd60e31287
-size 71906

--- a/testinput_tier_1/testwork/gnssro_obs_2021080606_s_mpi7_0003.nc4
+++ b/testinput_tier_1/testwork/gnssro_obs_2021080606_s_mpi7_0003.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4469fe092a8b84b2d232ef798528ee338ad58cc7eebe94abb74cf6e57d7fa74f
-size 69858

--- a/testinput_tier_1/testwork/gnssro_obs_2021080606_s_mpi7_prep_file_info.nc4
+++ b/testinput_tier_1/testwork/gnssro_obs_2021080606_s_mpi7_prep_file_info.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d1f878af463352606f7705b8cdffff337b63d03fb90fc3752465fe1558df84e3
-size 17012

--- a/testinput_tier_1/testwork/gnssro_obs_2021080606_s_prep_file_info.nc4
+++ b/testinput_tier_1/testwork/gnssro_obs_2021080606_s_prep_file_info.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cf814027454e802284c86ef2578bbaab7e5febab9c2950d9ea3a8dbc80579487
-size 17012

--- a/testinput_tier_1/testwork/sondes_obs_2018041500_m_0000.nc4
+++ b/testinput_tier_1/testwork/sondes_obs_2018041500_m_0000.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3669a55d6ccf0a2faba9ee6665ffbff7cffc322115ce3c6690d9adbee8dc3349
-size 492396

--- a/testinput_tier_1/testwork/sondes_obs_2018041500_m_mpi7_0000.nc4
+++ b/testinput_tier_1/testwork/sondes_obs_2018041500_m_mpi7_0000.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:89768f28ba15699a11e43dbfdfe22c80385359d78e674d85bfd5e4b50f54fca1
-size 319668

--- a/testinput_tier_1/testwork/sondes_obs_2018041500_m_mpi7_0001.nc4
+++ b/testinput_tier_1/testwork/sondes_obs_2018041500_m_mpi7_0001.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8d5ead514900a4364cb67200b428c65955467b36915424ce5319ba614b854168
-size 319612

--- a/testinput_tier_1/testwork/sondes_obs_2018041500_m_mpi7_0002.nc4
+++ b/testinput_tier_1/testwork/sondes_obs_2018041500_m_mpi7_0002.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4deed07b6433d33aaea7335584ad9e36f3ecd4fe0279c0922b1b52f0faf7e6da
-size 319612

--- a/testinput_tier_1/testwork/sondes_obs_2018041500_m_mpi7_0003.nc4
+++ b/testinput_tier_1/testwork/sondes_obs_2018041500_m_mpi7_0003.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:be2885d8823381eaf2682f95bf499bfc2f1d403ce517502a7a2e1ac54ab3d3f5
-size 229352

--- a/testinput_tier_1/testwork/sondes_obs_2018041500_m_mpi7_prep_file_info.nc4
+++ b/testinput_tier_1/testwork/sondes_obs_2018041500_m_mpi7_prep_file_info.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce183d8026abb8aba1e9578c7f96608002a3a32dd3c394eff138e1c6a0c8c72c
-size 17012

--- a/testinput_tier_1/testwork/sondes_obs_2018041500_m_prep_file_info.nc4
+++ b/testinput_tier_1/testwork/sondes_obs_2018041500_m_prep_file_info.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6306c94a481ef9c08c5d6d75de2fc3c248f8aaaecf9a008b8947c01a012dfa77
-size 17012


### PR DESCRIPTION
## Description

This PR removes the contrived tests files that were used for testing the reader until the standalone app was finished.

## Issue(s) addressed

Paritally resolves jcsda-internal/ioda/issues/1203

## Dependencies

List the other PRs that this PR is dependent on:
- [ ] merge with jcsda-internal/ioda/pull/1236

## Impact

Expected impact on downstream repositories:
None: this is for the new reader which is not the default reader yet

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (N/A)
- [x] I have run the unit tests before creating the PR
