### PR TITLE
New test files for the io pool based reader tests with windborne obs type

### DIFF
--- a/testinput_tier_1/test_reference/windborne_obs_2022021600_s_time_reader_pool_ext_file_prep.nc4
+++ b/testinput_tier_1/test_reference/windborne_obs_2022021600_s_time_reader_pool_ext_file_prep.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93b55b7a743a8de735284b0905ce0fb6e2d232679bb88aee494c39c195ec94ac
+size 75053

--- a/testinput_tier_1/test_reference/windborne_obs_2022021600_s_time_reader_pool_ext_file_prep_mpi7.nc4
+++ b/testinput_tier_1/test_reference/windborne_obs_2022021600_s_time_reader_pool_ext_file_prep_mpi7.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7eb38b2c14fa9eba48941769adbe895d5dd6b574c1060e379d4b439dcb2c9fd8
+size 75053

--- a/testinput_tier_1/windborne_obs_2022021600_s.nc4
+++ b/testinput_tier_1/windborne_obs_2022021600_s.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2fcf99a7b7a630392b38e1fe97140c670000c91ffa200e109bc288226403e76
+size 72141


### PR DESCRIPTION
## Description

This PR contains new test files for the new io pool based reader tests that verify proper handling of MPI tasks ending up with zero obs.

## Issue(s) addressed

Partially addresses jcsda-internal/ioda/issues/1263

## Dependencies

List the other PRs that this PR is dependent on:
- [ ] merge before or with jcsda-internal/ioda/pull/1265

## Impact

Expected impact on downstream repositories:

None - this is related to the new io pool based reader which is not being used yet

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (n/a)
- [x] I have run the unit tests before creating the PR
