### PR TITLE
Increase cmake_minimum_required to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # IODA Test Files
 ################################################################################
 
-cmake_minimum_required( VERSION 3.3.2 FATAL_ERROR )
+cmake_minimum_required( VERSION 3.12 )
 
 project( ioda_data VERSION 2.9.0 DESCRIPTION "IODA Test Files" )
 


### PR DESCRIPTION
## Description

Match that of oops, ufo and many other JEDI projects.
Prevent deprecation warnings from cmake 3.30+.

```
CMake Deprecation Warning at ioda-data/CMakeLists.txt:10 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

See also https://github.com/JCSDA-internal/ufo-data/pull/443.

## Issue(s) addressed

-na-

## Dependencies

-na-

## Impact

ioda-data will now require cmake 3.12, less than ioda's requirement of 3.14, but matching most other JEDI projects.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
