### PR TITLE
Add test files for the new ioda-filterObs.x application

### DIFF
--- a/testinput_tier_1/filter_obs_multi_file_p1.nc4
+++ b/testinput_tier_1/filter_obs_multi_file_p1.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c55f2d5e2ba45cbab180722f42b9a706c47aa294ae74e5194ce736dfac5554aa
+size 8730

--- a/testinput_tier_1/filter_obs_multi_file_p2.nc4
+++ b/testinput_tier_1/filter_obs_multi_file_p2.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b235c436edadd2ccf44c73e2966f98daf9e97144de3704ac042ef719b04255a
+size 8730

--- a/testinput_tier_1/filter_obs_single_file.nc4
+++ b/testinput_tier_1/filter_obs_single_file.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3fe57553e83c57f6b571d4d5596af678ea09a0284689d29d83ffa8c1bd661a6
+size 8870

--- a/testinput_tier_1/test_reference/filter_obs_multi_file_input.nc4
+++ b/testinput_tier_1/test_reference/filter_obs_multi_file_input.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7257f415c3bc0a2cb6cecf8fed3eaa24a76bbdf4136129b5646088bb262fdc03
+size 22266

--- a/testinput_tier_1/test_reference/filter_obs_single_file_input.nc4
+++ b/testinput_tier_1/test_reference/filter_obs_single_file_input.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce192f151ca878574dd8e12b8733ba3e67cec994a82ded41dc9de732f0d738b6
+size 22266


### PR DESCRIPTION
## Description

This PR adds in new test reference files for the new ioda-filterObs.x application.

## Issue(s) addressed

Parially addresses jcsda-internal/ioda/issues/1368

## Dependencies

- [x] merge before or with jcsda-internal/ioda/pull/1378

## Impact

Expected impact on downstream repositories:
None - new application

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (N/A)
- [x] I have run the unit tests before creating the PR
