### PR TITLE
Added amsua_n19 obs, geoval, and satbias files made by GFS GSI in all-sky

### DIFF
--- a/testinput_tier_1/amsua_n19.satbias.2024021900.nc
+++ b/testinput_tier_1/amsua_n19.satbias.2024021900.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ef5e377440c40c7a2ef42a05c6d297e3d11ee57e824375ec4c202442fb220c8
+size 22260

--- a/testinput_tier_1/amsua_n19.satbias.2024021900.nc
+++ b/testinput_tier_1/amsua_n19.satbias.2024021900.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3ef5e377440c40c7a2ef42a05c6d297e3d11ee57e824375ec4c202442fb220c8
-size 22260

--- a/testinput_tier_1/amsua_n19_geoval_2024021900m.nc4
+++ b/testinput_tier_1/amsua_n19_geoval_2024021900m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6140248af83013cf87b526b55f4e90b4d78d774ab22be3fd1e3c6a21b8d3e1e
+size 2897424

--- a/testinput_tier_1/amsua_n19_obs_2024021900m.nc4
+++ b/testinput_tier_1/amsua_n19_obs_2024021900m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea9318a1bc5148fe66d7603d739b9f6a13b95d1dbc53096304da51ae0ecd11aa
+size 140692


### PR DESCRIPTION
Additional AMSU-A N19 testing files for testing new UFO obs functions and configurations to assimilation AMSU-A N19 as in GFS GSI in all-sky conditions with precipitable hydrometeors.   Various geoval variables for cloud properties are added. 


## Issue(s) addressed

Resolves #<issue_number>

## Dependencies

List the other PRs that this PR is dependent on:
- [ ] ...

## Impact None

Expected impact on downstream repositories:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
