### PR TITLE
Update test reference files for filterObs tests

### DIFF
--- a/testinput_tier_1/test_reference/filter_obs_amsua_n19_obs_2018041500_m.nc4
+++ b/testinput_tier_1/test_reference/filter_obs_amsua_n19_obs_2018041500_m.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:37ef90eb8e58dbc4270adb4f47d0bc17096b3304af305ea8c989550ea8a84601
+oid sha256:96dc03edb3dc396e9e0535a44013e57461a7452b6a6cbe87e8cd28b96c06f88b
 size 143535

--- a/testinput_tier_1/test_reference/filter_obs_sondes_obs_2018041500_m.nc4
+++ b/testinput_tier_1/test_reference/filter_obs_sondes_obs_2018041500_m.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5bc06f89b74cf6d1a42fe8060b37ab116454c3029af7346531aa482d253a322e
+oid sha256:5a0e47f9dfedd07069e5cb4af782d422d4660e6acb76760e0d8782d43ee42310
 size 483360


### PR DESCRIPTION
## Description

This PR updates the amsua and sondes test files for the filterObs.x application ctests. This is being done since the generate receipt time function has been changed to an integer math algorithm to help with reproducibility.

## Issue(s) addressed

Needed for ctest repair sprint

## Dependencies

List the other PRs that this PR is dependent on:
- [x] merge with jcsda-internal/ioda/pull/1435

## Impact

Expected impact on downstream repositories:
None - this is for new functionality

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (N/A)
- [x] I have run the unit tests before creating the PR
