### PR TITLE
Parallel ODB reader

### DIFF
--- a/testinput_tier_1/atms-variable-sized-frames.odb
+++ b/testinput_tier_1/atms-variable-sized-frames.odb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16f479659eda16b85e8bd31c9cc6c5229d86bd1fcb51ce1302667a4dd460e8ab
+size 2152958


### PR DESCRIPTION
## Description

This PR adds an ODB file containing the same rows as `atms.odb`, but consisting of multiple small frames of different sizes (1 up to 50 rows), so that some seqnos are split into multiple frames. It will be handy for testing parallel ODB reading.

## Issue(s) addressed

Contributes towards the resolution of https://github.com/JCSDA-internal/ioda/issues/1436.

## Dependencies

None

## Impact

Expected impact on downstream repositories: None.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
