### PR TITLE
Add utility to archive ioda-data for tests

### DIFF
--- a/.github/workflows/push-to-s3.yaml
+++ b/.github/workflows/push-to-s3.yaml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - develop
+  schedule:
+    # 1:30 AM on the 1st and 15th day of each month.
+    - cron: 30 1 1,15 * *
 
 jobs:
   upload:

--- a/.github/workflows/push-to-s3.yaml
+++ b/.github/workflows/push-to-s3.yaml
@@ -36,7 +36,10 @@ jobs:
           LFS_BUCKET_AND_PATH: jcsda-usaf-ci-build-cache/lfs
         run: |
           export repository_name=$(basename $(pwd))
-          echo "repository_name=${repository_name}"
+          echo "Prep repo ${repository_name} for upload"
+          git fetch --all
+          git checkout develop
+          git config --local --remove-section 'http.https://github.com/'
           echo "Creating this tarball can take several minutes."
           cd ..
           tar -czf "${repository_name}.tar.gz" "${repository_name}"

--- a/.github/workflows/push-to-s3.yaml
+++ b/.github/workflows/push-to-s3.yaml
@@ -6,9 +6,6 @@ on:
   push:
     branches:
       - develop
-  pull_request:
-    branches:
-      - develop
 
 jobs:
   upload:

--- a/.github/workflows/push-to-s3.yaml
+++ b/.github/workflows/push-to-s3.yaml
@@ -1,0 +1,44 @@
+# On push to develop this workflow will create a tarball of the repository
+# and push it to the s3 path defined by LFS_BUCKET_AND_PATH. This tarball is
+# used by our testing infrastructure to save GitLFS bandwidth.
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          # This role only has the permission to write to our lfs archive s3 bucket path.
+          role-to-assume: arn:aws:iam::747101682576:role/github-git-lfs-archive-writer
+          aws-region: us-east-2
+
+      - name: Create tarball and upload to s3
+        env:
+          LFS_BUCKET_AND_PATH: jcsda-usaf-ci-build-cache/lfs
+        run: |
+          export repository_name=$(basename $(pwd))
+          echo "repository_name=${repository_name}"
+          echo "Creating this tarball can take several minutes."
+          cd ..
+          tar -czf "${repository_name}.tar.gz" "${repository_name}"
+          echo "Uploading to s3"
+          aws s3 cp "${repository_name}.tar.gz" "s3://${LFS_BUCKET_AND_PATH}/${repository_name}.tar.gz" --no-progress

--- a/.github/workflows/push-to-s3.yaml
+++ b/.github/workflows/push-to-s3.yaml
@@ -35,6 +35,7 @@ jobs:
         env:
           LFS_BUCKET_AND_PATH: jcsda-usaf-ci-build-cache/lfs
         run: |
+          set -e
           export repository_name=$(basename $(pwd))
           echo "Prep repo ${repository_name} for upload"
           git fetch --all


### PR DESCRIPTION
This should reduce our GitLFS bandwidth use by tests.

Helps resolve https://github.com/JCSDA-internal/ioda-data/issues/217

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR