### PR TITLE
Parallel reading of ODB files with radar observations

### DIFF
--- a/testinput_tier_1/radar_doppler_wind_multiple_records.odb
+++ b/testinput_tier_1/radar_doppler_wind_multiple_records.odb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f2d444de44c13584c1c95ad1f161c5952544766decb798b9d73b4d4ee81a3cb
+size 215343


### PR DESCRIPTION
## Description

This PR adds an ODB file with 5 radar records (grouped by date, time, radar_beam_elevation and radar_identifier) split into 17 frames.

It was created using the following Bash script:

```bash
#!/bin/bash
rm radar_doppler_wind_multiple_records-chunk-*.odb
odc mdset "date=20240101,time=2100,radar_beam_elevation=1,radar_identifier=4" radar_doppler_wind.odb radar_doppler_wind_1.odb
odc mdset "date=20240101,time=2200,radar_beam_elevation=1,radar_identifier=4" radar_doppler_wind.odb radar_doppler_wind_2.odb 
odc mdset "date=20240101,time=2200,radar_beam_elevation=2,radar_identifier=4" radar_doppler_wind.odb radar_doppler_wind_3.odb 
odc mdset "date=20240101,time=2300,radar_beam_elevation=2,radar_identifier=4" radar_doppler_wind.odb radar_doppler_wind_4.odb 
odc mdset "date=20240101,time=2300,radar_beam_elevation=2,radar_identifier=5" radar_doppler_wind.odb radar_doppler_wind_5.odb 
cat radar_doppler_wind_[1-5].odb > radar_doppler_wind_multiple_records_in_their_own_frames.odb
for i in {0..20}; do odc sql "select * where rownumber() >= $i*30 and rownumber() < ($i+1)*30" -i radar_doppler_wind_multiple_records_in_their_own_frames.odb -o radar_doppler_wind_multiple_records-chunk-$i.odb; done
cat radar_doppler_wind_multiple_records-chunk-?.odb radar_doppler_wind_multiple_records-chunk-??.odb > radar_doppler_wind_multiple_records.odb
rm radar_doppler_wind_multiple_records_in_their_own_frames.odb
rm radar_doppler_wind_multiple_records-chunk-*.odb
rm radar_doppler_wind_[1-5].odb
```

## Issue(s) addressed

Contributes towards resolution of https://github.com/JCSDA-internal/ioda/issues/1490.

## Dependencies

None

## Impact

Expected impact on downstream repositories: None

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
