### PR TITLE
Generate project config with ecbuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,13 @@
-# (C) Copyright 2017-2022 UCAR.
+# (C) Copyright 2017-2025 UCAR.
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+cmake_minimum_required(VERSION 3.12)
+project(ioda-data VERSION 2.9.0 DESCRIPTION "IODA Test Files")
 
-################################################################################
-# IODA Test Files
-################################################################################
-
-cmake_minimum_required( VERSION 3.12 )
-
-project( ioda_data VERSION 2.9.0 DESCRIPTION "IODA Test Files" )
-
+find_package(ecbuild QUIET)
+include(ecbuild_system NO_POLICY_SCOPE)
+ecbuild_declare_project()
+set(CMAKE_DIRECTORY_LABELS ${PROJECT_NAME})
+ecbuild_install_project(NAME ${PROJECT_NAME})
+ecbuild_print_summary()


### PR DESCRIPTION
## Description

To allow downstream project to find use CMake's `find_package(ioda-data)`.

## Impact

Downstream projects can now use CMake's `find_package(ioda-data)`.

## See also

- JCSDA-internal/saber#1079
  - JCSDA-internal/saber#1099
- JCSDA-internal/vader#308
  - JCSDA-internal/vader#316
- JCSDA-internal/jedi-model-data#4
- JCSDA-internal/ufo#3806
- JCSDA-internal/ufo-data#507
- JCSDA-internal/ioda#1512
- JCSDA-internal/ioda-data#224

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
