### PR TITLE
New test reference files for the placeholder osdf writer.

### DIFF
--- a/testinput_tier_1/test_reference/amsua_n19_obs_2018041500_m_time_osdf.nc4
+++ b/testinput_tier_1/test_reference/amsua_n19_obs_2018041500_m_time_osdf.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e73dc8ffc934e6b07938813f0286e281327570c570ef40992acdf6375b5e7a1
+size 686

--- a/testinput_tier_1/test_reference/sondes_obs_2018041500_m_time_osdf.nc4
+++ b/testinput_tier_1/test_reference/sondes_obs_2018041500_m_time_osdf.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e73dc8ffc934e6b07938813f0286e281327570c570ef40992acdf6375b5e7a1
+size 686


### PR DESCRIPTION
## Description

This PR adds two new test reference files for the new ctests that exercise the placeholder OSDF writer.

## Issue(s) addressed

Partially addresses jcsda-internal/ioda/issues/1551

## Dependencies

List the other PRs that this PR is dependent on:
- [x] merge before or with jcsda-internal/ioda/pull/1552

## Impact

Expected impact on downstream repositories:
 None - new functionality that is not being used yet

## Manual Testing Instructions (optional)

If you would like your reviewers to manually build and test the change, please include
instructions on how the change should be built and tested. Also include a short
justification on why manual testing is necessary for this change.

## Checklist

- [x] I have performed a self-review of my own code
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
