### PR TITLE
Test reference file for new ioda_random_obsvector_io_osdf test

### DIFF
--- a/testinput_tier_1/test_reference/amsua_n19_obs_2018041500_m_rand_ovec_io_osdf.nc4
+++ b/testinput_tier_1/test_reference/amsua_n19_obs_2018041500_m_rand_ovec_io_osdf.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:588207b3fe51a10dba58e8ca9151a1c065cea4b116fceff71ce7c36fb94932f8
+size 420198


### PR DESCRIPTION
## Description

This PR provides a new test reference file for the new ioda_random_obsvector_io_osdf test (which exercises the bottleneck fix for the OSDF based put_db function).

## Issue(s) addressed

Partially addresses jcsda-internal/ioda/issues/1703

## Dependencies

List the other PRs that this PR is dependent on:
- [x] merge before or with jcsda-internal/ioda/pull/1705

## Impact

Expected impact on downstream repositories:
 None - new feature that is not being used yet

## Manual Testing Instructions (optional)

If you would like your reviewers to manually build and test the change, please include
instructions on how the change should be built and tested. Also include a short
justification on why manual testing is necessary for this change.

## Checklist

- [x] I have performed a self-review of my own code
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
