### PR TITLE
Reference files to test odc to nc4 output

### DIFF
--- a/testinput_tier_1/test_reference/aircraft_time_osdf_odc_to_nc4.nc4
+++ b/testinput_tier_1/test_reference/aircraft_time_osdf_odc_to_nc4.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b47c09c813d92fc0aff1f0f937f307250f647fbe76b948a2bba9d529cc05f10b
+size 117362

--- a/testinput_tier_1/test_reference/atms_time_osdf_odc_to_nc4.nc4
+++ b/testinput_tier_1/test_reference/atms_time_osdf_odc_to_nc4.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6932b64a603821fc30420654c6b806c1d03541e27c9e3155e4fb61cf66e08fbf
+size 170146


### PR DESCRIPTION
## Description

This PR adds reference files for new tests in ioda which check whether expected results are produced when reading in from an odb file and writing to an nc4 file. In particular, this is used to confirm that receiptdateTime and dateTime are given the correct "seconds since 1970......" units and the remainder of the units are "MISSING*."

## Dependencies

List the other PRs that this PR is dependent on:
- [x] JCSDA-internal/ioda/pull/1714

build-group=JCSDA-internal/ioda/pull/1714

## Impact

Expected impact on downstream repositories: N/A - testing new functionality

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
