### PR TITLE
Test reference files for the empty obs file and filter to zero obs tests

### DIFF
--- a/testinput_tier_1/test_reference/filter_to_zero_obs.amsua.nc4
+++ b/testinput_tier_1/test_reference/filter_to_zero_obs.amsua.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7fcf1fc24be1f5c100aacb11011ab4a9b80dd9526a6a7e7a5c004dde22a3de94
+size 53709

--- a/testinput_tier_1/test_reference/filter_to_zero_obs.amsua.osdf.nc4
+++ b/testinput_tier_1/test_reference/filter_to_zero_obs.amsua.osdf.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:129467b075e9ddb9aaf47db37efa811e3ca92c687218082bff7b305b992efa8c
+size 26886

--- a/testinput_tier_1/test_reference/filter_to_zero_obs.sondes.nc4
+++ b/testinput_tier_1/test_reference/filter_to_zero_obs.sondes.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:977a2cd9314efa408ad6562a1def53dd67f523eb4f9ac465830bba04f39de62e
+size 44927

--- a/testinput_tier_1/test_reference/filter_to_zero_obs.sondes.osdf.nc4
+++ b/testinput_tier_1/test_reference/filter_to_zero_obs.sondes.osdf.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19143f3f0e88d62cfb74879eb5baf4370d1a773e3ac6087669c1e7afe7d17541
+size 46236

--- a/testinput_tier_1/test_reference/ospace.empty_obs_file.nc4
+++ b/testinput_tier_1/test_reference/ospace.empty_obs_file.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c85e821b3e96e40e7311bd0296a2ad100f26aea034b92f7a6ef3616a712c29a
+size 6144

--- a/testinput_tier_1/test_reference/ospace.empty_obs_file_with_channels.nc4
+++ b/testinput_tier_1/test_reference/ospace.empty_obs_file_with_channels.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c85e821b3e96e40e7311bd0296a2ad100f26aea034b92f7a6ef3616a712c29a
+size 6144

--- a/testinput_tier_1/test_reference/ospace_osdf.empty_obs_file.nc4
+++ b/testinput_tier_1/test_reference/ospace_osdf.empty_obs_file.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0a5f4d52c938e93b8f00694c0c041db37d5939f1cf3e3082d783909358639449
-size 647
+oid sha256:e8cbac8fb81552dc64582841dfb4724edfabb9d771be3716f18745eb45ec013f
+size 766

--- a/testinput_tier_1/test_reference/ospace_osdf.empty_obs_file.nc4
+++ b/testinput_tier_1/test_reference/ospace_osdf.empty_obs_file.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a5f4d52c938e93b8f00694c0c041db37d5939f1cf3e3082d783909358639449
+size 647

--- a/testinput_tier_1/test_reference/ospace_osdf.empty_obs_file_with_channels.nc4
+++ b/testinput_tier_1/test_reference/ospace_osdf.empty_obs_file_with_channels.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0a5f4d52c938e93b8f00694c0c041db37d5939f1cf3e3082d783909358639449
-size 647
+oid sha256:e8cbac8fb81552dc64582841dfb4724edfabb9d771be3716f18745eb45ec013f
+size 766

--- a/testinput_tier_1/test_reference/ospace_osdf.empty_obs_file_with_channels.nc4
+++ b/testinput_tier_1/test_reference/ospace_osdf.empty_obs_file_with_channels.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a5f4d52c938e93b8f00694c0c041db37d5939f1cf3e3082d783909358639449
+size 647


### PR DESCRIPTION
## Description

This PR adds in new reference files for two sets of tests ("empty obs file" and "filter to zero obs") and for both ObsGroup and OSDF based flows.

## Issue(s) addressed

Partially addresses jcsda-internal/ioda/issues/1736

## Dependencies

List the other PRs that this PR is dependent on:
- [x] merge with jcsda-internal/ioda/pull/1740

## Impact

Expected impact on downstream repositories:
None - these are related to test updates that were noticed when adding OSDF versions of existing ObsGroup tests

## Manual Testing Instructions (optional)

If you would like your reviewers to manually build and test the change, please include
instructions on how the change should be built and tested. Also include a short
justification on why manual testing is necessary for this change.

## Checklist

- [x] I have performed a self-review of my own code
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
