### PR TITLE
Test file for the OSDF reader with float dimension coordinates

### DIFF
--- a/testinput_tier_1/osdf_reader_float_channel.nc4
+++ b/testinput_tier_1/osdf_reader_float_channel.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27b6016edeb876feb1e41112fa282debd6c9bd7e8cab03ad2346c6bfb62bebb5
+size 10469


### PR DESCRIPTION
## Description

This PR adds a new test file for verifying that the OSDF reader can handle dimensions (eg, Channel) with float coordinate values in an input netcdf file.

## Issue(s) addressed

Partially addresses jcsda-internal/ioda/issues/1787

## Dependencies

List the other PRs that this PR is dependent on:
- [ ] merge before or with jcsda-internal/ioda/pull/1792

## Impact

Expected impact on downstream repositories:

## Manual Testing Instructions (optional)

If you would like your reviewers to manually build and test the change, please include
instructions on how the change should be built and tested. Also include a short
justification on why manual testing is necessary for this change.

## Checklist

- [x] I have performed a self-review of my own code
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
