### PR TITLE
Test file for new inf/nan handling in the OSDF reader

### DIFF
--- a/testinput_tier_1/osdf_reader_nan_missing.nc4
+++ b/testinput_tier_1/osdf_reader_nan_missing.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:270c0eb70cca9e966072a54791cdcdaca7eb443bef159b1c6dcfffd0c18e1f91
+size 10208


### PR DESCRIPTION
## Description

This PR provides a new test file for the OSDF reader test that includes +/-inf and nan in the input file data.

## Issue(s) addressed

Partially addresses jcsda-internal/ioda/issues/1800

## Dependencies

List the other PRs that this PR is dependent on:
- [x] merge before or with jcsda-internal/ioda/pull/1801

## Impact

Expected impact on downstream repositories: None

## Manual Testing Instructions (optional)

If you would like your reviewers to manually build and test the change, please include
instructions on how the change should be built and tested. Also include a short
justification on why manual testing is necessary for this change.

## Checklist

- [x] I have performed a self-review of my own code
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
