### PR TITLE
Input and reference file for testing null channel index

### DIFF
--- a/testinput_tier_1/airs_codb_1.odb
+++ b/testinput_tier_1/airs_codb_1.odb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:317fa19eeac1e3520ad5d4c22862e759976c0b9ff1b02a4fc68b2de8fec8e00d
+size 37456

--- a/testinput_tier_1/test_reference/obsspace_null_channel.odb
+++ b/testinput_tier_1/test_reference/obsspace_null_channel.odb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:33eacfb58c59b77c71cc61d9a696c2098322cc34456e83693e17b141bf187585
+oid sha256:fcdbd1e3679fea4663680bddab268e9b0a0c816a24145bb48ae04704ed0792e0
 size 54238

--- a/testinput_tier_1/test_reference/obsspace_null_channel.odb
+++ b/testinput_tier_1/test_reference/obsspace_null_channel.odb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33eacfb58c59b77c71cc61d9a696c2098322cc34456e83693e17b141bf187585
+size 54238

--- a/testinput_tier_1/test_reference/obsspace_null_channel_osdf.odb
+++ b/testinput_tier_1/test_reference/obsspace_null_channel_osdf.odb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33eacfb58c59b77c71cc61d9a696c2098322cc34456e83693e17b141bf187585
+size 54238


### PR DESCRIPTION
## Description

Input and reference file for testing reading a file where a variable has a channel, or channels, with number given by the `odb_missing_float` value (given by `NULL` in the odb file). These rows should be excluded from the read by the sql query `initial_vertco_reference  is not null` hence do not appear in the reference file.

## Dependencies

List the other PRs that this PR is dependent on:
- [x] Merge with https://github.com/JCSDA-internal/ioda/pull/1831

## Impact

Expected impact on downstream repositories: N/A

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
