### PR TITLE
New test file for the new ioda_reader_fillvalue test

### DIFF
--- a/testinput_tier_1/osdf_reader_byte_nofill.nc4
+++ b/testinput_tier_1/osdf_reader_byte_nofill.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c11066188b4177ad3b27fdaccc2194b22e1efe49e8a9e15243dcf5c5778fdca3
+size 10476

--- a/testinput_tier_1/osdf_reader_byte_nofill.nc4
+++ b/testinput_tier_1/osdf_reader_byte_nofill.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c11066188b4177ad3b27fdaccc2194b22e1efe49e8a9e15243dcf5c5778fdca3
-size 10476

--- a/testinput_tier_1/osdf_reader_fillvalues.nc4
+++ b/testinput_tier_1/osdf_reader_fillvalues.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48ee720bf49f5915ae35bc2df974f21b9467ea5e4243340e9d0ce380b47b9101
+size 16795


### PR DESCRIPTION
## Description

This PR provides a new test input file for the ioda_reader_fillvalue test.

## Issue(s) addressed

Partially addresses jcsda-internal/ioda/issues/1860

## Dependencies

List the other PRs that this PR is dependent on:
- [x] merge with jcsda-internal/ioda/pull/1867

## Impact

Expected impact on downstream repositories:
None - OSDF only change and OSDF is not in production use yet

## Manual Testing Instructions (optional)

If you would like your reviewers to manually build and test the change, please include
instructions on how the change should be built and tested. Also include a short
justification on why manual testing is necessary for this change.

## Checklist

- [x] I have performed a self-review of my own code
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
