### PR TITLE
New test input files for the ioda_reader_var_collision test

### DIFF
--- a/testinput_tier_1/osdf_reader_var_collision_no_slice_dim.nc4
+++ b/testinput_tier_1/osdf_reader_var_collision_no_slice_dim.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:894b40240253d8617563c2e5f2ff3d06e5fa2c07ca72b9a75a5e24505bc485b4
+size 8854

--- a/testinput_tier_1/osdf_reader_var_collision_two_pairs.nc4
+++ b/testinput_tier_1/osdf_reader_var_collision_two_pairs.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5a488532a60222f27fbf391d44760a9ee3931d131e9c355ab5f2eff75691c63
+size 11011

--- a/testinput_tier_1/osdf_reader_var_collision_unused_suffix.nc4
+++ b/testinput_tier_1/osdf_reader_var_collision_unused_suffix.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9596045a9d67e7a11eee5c411fdf13b45c1faa0ebb292ed268271e122d0472dd
+size 9734


### PR DESCRIPTION
## Description

This PR adds new test files for the new ioda_reader_var_collision test. 

## Issue(s) addressed

Works toward jcsda-internal/ioda/issues/1845

## Dependencies

List the other PRs that this PR is dependent on:
- [ ] merge before or with jcsda-internal/ioda/pull/1853

## Impact

Expected impact on downstream repositories:
See jcsda-internal/ioda/pull/1853 for details

## Manual Testing Instructions (optional)

If you would like your reviewers to manually build and test the change, please include
instructions on how the change should be built and tested. Also include a short
justification on why manual testing is necessary for this change.

## Checklist

- [x] I have performed a self-review of my own code
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
